### PR TITLE
Use SHA256 rather than SHA1 hash, since calling Formula.sha1 is now…

### DIFF
--- a/libschwa.rb
+++ b/libschwa.rb
@@ -3,7 +3,7 @@ require "formula"
 class Libschwa < Formula
   homepage "https://github.com/schwa-lab/libschwa"
   url "https://github.com/schwa-lab/libschwa/releases/download/0.4.0/libschwa-0.4.0.tar.gz"
-  sha1 "b8d4f7796d55c5b2a733506e59382141fb0187f1"
+  sha256 "09c9b8db339b44ce251a1289a5075dcf2b5edf4b8cde05af97f6e992bc12e617"
 
   depends_on "pkg-config"
   depends_on "zeromq" => :optional


### PR DESCRIPTION
… disabled in Homebrew.